### PR TITLE
Added article for no published content page configuration

### DIFF
--- a/Articles/Configuration/no-published-content-page.md
+++ b/Articles/Configuration/no-published-content-page.md
@@ -1,0 +1,54 @@
+# No Published Content Page
+
+When Umbraco is first installed, if no starter kit is chosen, there will be no content created in the backoffice, and no published content to display.
+
+It's also possible to create content, but have it unpublished.
+
+If browsing the front-end of the website, when this situation of no published content is found, a custom page is displayed.
+
+This page is served from `~/umbraco/UmbracoWebsite/NoNodes.cshtml`.
+
+## Customising The Page
+
+Whilst the contents of this page can be edited directly, this isn't recommended, as care would need to be taken to avoid the changes getting overwritten in upgrades.
+
+Instead there are two options.
+
+To return the contents of a different Razor file, create this file at your chosen location and configure it's use within the `Global` section of the `appsettings.json` file:
+
+```
+"Umbraco": {
+    "CMS": {
+      ...
+      "Global": {
+        ...
+        "NoNodesViewPath": "~/Views/CustomNoNodes.cshtml",
+        ...
+      },
+	  ...
+```
+
+For finer control, you can write code to handle the route directly, allowing the implementation of a custom controller, view model and view:
+
+```
+    public class CustomNoNodesComposer: ComponentComposer<CustomNoNodesComponent>, IUserComposer
+    {
+    }
+
+    public class CustomNoNodesComponent : IComponent
+    {
+        public void Initialize()
+        {
+            if (RouteTable.Routes[Constants.Web.NoContentRouteName] is Route route)
+            {
+                route.Defaults = new RouteValueDictionary()
+                {
+                    ["controller"] = "CustomNoNodes",
+                    ["action"] = "Index"
+                };
+            }
+        }
+
+        public void Terminate() { }
+    }
+```

--- a/Articles/Configuration/no-published-content-page.md
+++ b/Articles/Configuration/no-published-content-page.md
@@ -12,43 +12,20 @@ This page is served from `~/umbraco/UmbracoWebsite/NoNodes.cshtml`.
 
 Whilst the contents of this page can be edited directly, this isn't recommended, as care would need to be taken to avoid the changes getting overwritten in upgrades.
 
-Instead there are two options.
+Instead a better approach is to create your own view file and apply a configuration setting to indicate the path to the view to use.
 
-To return the contents of a different Razor file, create this file at your chosen location and configure it's use within the `Global` section of the `appsettings.json` file:
+To return the contents of a different file, create it at your chosen location and configure it's use by adding an entry for `NoNodesViewPath` at the following path: `Umbraco:CMS:Global`.
+
+This configuration can be setup in a configuration source of your choice.  For the default JSON based configuration you can apply this to `appSettings.json` (or `appSettings.<environment>.json`, e.g. `appSettings.Development.json`) as follows:
 
 ```
 "Umbraco": {
-    "CMS": {
+  "CMS": {
+    ...
+    "Global": {
       ...
-      "Global": {
-        ...
-        "NoNodesViewPath": "~/Views/CustomNoNodes.cshtml",
-        ...
-      },
-	  ...
-```
-
-For finer control, you can write code to handle the route directly, allowing the implementation of a custom controller, view model and view:
-
-```
-    public class CustomNoNodesComposer: ComponentComposer<CustomNoNodesComponent>, IUserComposer
-    {
-    }
-
-    public class CustomNoNodesComponent : IComponent
-    {
-        public void Initialize()
-        {
-            if (RouteTable.Routes[Constants.Web.NoContentRouteName] is Route route)
-            {
-                route.Defaults = new RouteValueDictionary()
-                {
-                    ["controller"] = "CustomNoNodes",
-                    ["action"] = "Index"
-                };
-            }
-        }
-
-        public void Terminate() { }
-    }
+      "NoNodesViewPath": "~/Views/CustomNoNodes.cshtml",
+      ...
+    },
+    ...
 ```


### PR DESCRIPTION
I've put this into a folder `Configuration` under `Articles` - can be re-arranged when there's more articles of course, but it seems like a "Configuration" section will be useful.