### PR TITLE
Migrating Extending Backoffice Search docs

### DIFF
--- a/Articles/Backoffice-Search/extending.md
+++ b/Articles/Backoffice-Search/extending.md
@@ -44,7 +44,7 @@ public class MyComposer : IUserComposer
 ```csharp
 public class CustomUmbracoTreeSearcherFields : UmbracoTreeSearcherFields, IUmbracoTreeSearcherFields
 {
-    public List<string> GetBackOfficeFields()
+    public IEnumerable<string> GetBackOfficeFields()
     {
         return new List<string>(base.GetBackOfficeFields()) { "parentID" };
     }
@@ -56,7 +56,7 @@ public class CustomUmbracoTreeSearcherFields : UmbracoTreeSearcherFields, IUmbra
 ```csharp
 public class CustomUmbracoTreeSearcherFields : UmbracoTreeSearcherFields, IInternalSearchConstants
 {
-    public List<string> GetBackOfficeDocumentFields()
+    public IEnumerable<string> GetBackOfficeDocumentFields()
     {
         return new List<string>(base.GetBackOfficeDocumentFields()) { "parentID" };
     }
@@ -68,7 +68,7 @@ public class CustomUmbracoTreeSearcherFields : UmbracoTreeSearcherFields, IInter
 ```csharp
 public class CustomUmbracoTreeSearcherFields : UmbracoTreeSearcherFields, IUmbracoTreeSearcherFields
 {
-    public List<string> GetBackOfficeMediaFields()
+    public IEnumerable<string> GetBackOfficeMediaFields()
     {
        return new List<string>(base.GetBackOfficeMediaFields()) { "parentID" };
     }
@@ -80,7 +80,7 @@ public class CustomUmbracoTreeSearcherFields : UmbracoTreeSearcherFields, IUmbra
 ```csharp
 public class CustomUmbracoTreeSearcherFields : UmbracoTreeSearcherFields,     IUmbracoTreeSearcherFields
 {
-    public List<string> GetBackOfficeMembersFields()
+    public IEnumerable<string> GetBackOfficeMembersFields()
     {
         return new List<string>(base.GetBackOfficeMembersFields()) { "parentID" };
     }

--- a/Articles/Backoffice-Search/extending.md
+++ b/Articles/Backoffice-Search/extending.md
@@ -70,7 +70,7 @@ public class CustomUmbracoTreeSearcherFields : UmbracoTreeSearcherFields, IUmbra
 {
     public List<string> GetBackOfficeMediaFields()
     {
-       return new List<string>(base.GetBackOfficeDocumentFields()) { "parentID" };
+       return new List<string>(base.GetBackOfficeMediaFields()) { "parentID" };
     }
 }
 ```

--- a/Articles/Backoffice-Search/extending.md
+++ b/Articles/Backoffice-Search/extending.md
@@ -1,0 +1,92 @@
+﻿# Backoffice Search
+
+The search facility of the Umbraco Backoffice allows the searching 'across sections' of different types of Umbraco entities, eg Content, Media, Members. However 'by default' only a small subset of standard fields are searched:
+
+| Node Type    | Propagated Fields      |
+| ------------ | ---------------------- |
+| All Nodes    | Id, __NodeId and __Key |
+| Media Nodes  | UmbracoFileFieldName   |
+| Member Nodes | email, loginName       |
+
+However, a specific Umbraco implementation may have additional custom properties that it would be useful to be considered in a Backoffice Search, for example perhaps there is an 'Organisation Name' property on the Member Type, or the 'Main Body Text' property of a Content item.
+
+## Adding custom properties to backoffice search
+
+To add custom properties, it is required to register a custom implementation of `IUmbracoTreeSearcherFields`. We recommend to override the existing `UmbracoTreeSearcherFields`.
+
+Your custom implementation needs to be registered in the container. E.g. in the `Startup.ConfigureServices` method or in a composer, as an alternative.
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddUmbraco(_env, _config)
+    ...
+
+    services.AddUnique<IUmbracoTreeSearcherFields, CustomUmbracoTreeSearcherFields>();
+}
+```
+
+or
+
+```csharp
+public class MyComposer : IUserComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+    builder.Services.AddUnique<IUmbracoTreeSearcherFields, CustomUmbracoTreeSearcherFields>();
+    }
+}
+```
+
+
+### All Node types
+
+```csharp
+public class CustomUmbracoTreeSearcherFields : UmbracoTreeSearcherFields, IUmbracoTreeSearcherFields
+{
+    public List<string> GetBackOfficeFields()
+    {
+        return new List<string>(base.GetBackOfficeFields()) { "parentID" };
+    }
+}
+```
+
+### Documents types
+
+```csharp
+public class CustomUmbracoTreeSearcherFields : UmbracoTreeSearcherFields, IInternalSearchConstants
+{
+    public List<string> GetBackOfficeDocumentFields()
+    {
+        return new List<string>(base.GetBackOfficeDocumentFields()) { "parentID" };
+    }
+}
+```
+
+### Media Types
+
+```csharp
+public class CustomUmbracoTreeSearcherFields : UmbracoTreeSearcherFields, IUmbracoTreeSearcherFields
+{
+    public List<string> GetBackOfficeMediaFields()
+    {
+       return new List<string>(base.GetBackOfficeDocumentFields()) { "parentID" };
+    }
+}
+```
+
+### Member Types
+
+```csharp
+public class CustomUmbracoTreeSearcherFields : UmbracoTreeSearcherFields,     IUmbracoTreeSearcherFields
+{
+    public List<string> GetBackOfficeMembersFields()
+    {
+        return new List<string>(base.GetBackOfficeMembersFields()) { "parentID" };
+    }
+}
+```
+
+## More advanced extensions
+
+For further extensibility of the Umbraco Backoffice search implementation check [ISearchableTree](https://our.umbraco.com/Documentation/Extending/Section-Trees/Searchable-Trees/ "https://our.umbraco.com/Documentation/Extending/Section-Trees/Searchable-Trees/")


### PR DESCRIPTION
# Details
- Updated the code examples. 
- Show how to replace the default implementation.
- I don't know what to do the with the absolute link at the bottom.

(Note the existing code examples does not seem to work for v8 neither, as `.Add(..)` is not available on IEnumerable