### PR TITLE
Migrate Language Files & Localization

### DIFF
--- a/Articles/Language-Files/extending.md
+++ b/Articles/Language-Files/extending.md
@@ -54,7 +54,7 @@ Using core or custom language keys from your code:
 
 
 ### From .NET
-`ILocalizedTextService` is is used to localize strings, and is available through dependency injection. First inject the service, and then use the Localize method available in the namespace `Umbraco.Extensions` to localize the string with the format [area]/[key]:
+`ILocalizedTextService` is used to localize strings, and is available through dependency injection. First, inject the service, and then use the `Localize()` method available in the namespace `Umbraco.Extensions` to localize the string with the format [area]/[key]:
 
 ```csharp
 public MyClass(ILocalizedTextService textservice)

--- a/Articles/Language-Files/extending.md
+++ b/Articles/Language-Files/extending.md
@@ -1,0 +1,135 @@
+# Language Files & Localization
+
+Language files are used to translate the Umbraco backoffice user interface so that end users can use Umbraco in their native language. This is particularly important for content editors who do not speak English.
+
+If you are a package developer, [see here for docs on how to include translations for your own package](Language-Files-For-Packages/index.md).
+
+## Supported Languages
+Current languages that are included in the core are:
+
+- English (UK)
+- English (US)
+- Danish
+- German
+- Spanish
+- French
+- Hebrew (Israel)
+- Italian
+- Japanese
+- Korean
+- Dutch
+- Norwegian
+- Polish
+- Portuguese
+- Russian
+- Swedish
+- Chinese
+- Chinese (Taiwan)
+- Czech
+- Turkish
+
+## Where to find the language files
+
+### Core language files
+The core Umbraco language files are found at the following location within the Umbraco source:
+
+    Umbraco-CMS/src/Umbraco.Web.UI.Netcore/umbraco/config/lang/
+
+These language files are the ones shipped with Umbraco and should not be modified.
+
+### Package language files
+If you are a package developer, [see here for docs on how to include translations for your own package](Language-Files-For-Packages/index.md), package language files are located in:
+
+    /App_Plugins/mypackage/lang/{language}.xml
+
+### User language files
+If you want to override Umbraco core translations or translations shipped with packages, you can do that too, these files are located here:
+
+    /config/lang/{language}.user.xml
+
+By default, these files are empty but you can add any new keys you want or override existing ones with your own translations. The nice part about the user files is that they will not get overwritten by the installer when you upgrade your Umbraco versions.
+
+## Using the language keys
+Using core or custom language keys from your code:
+
+
+### From .NET
+`ILocalizedTextService` is is used to localize strings, and is available through dependency injection. First inject the service, and then use the Localize method available in the namespace `Umbraco.Extensions` to localize the string with the format [area]/[key]:
+
+```csharp
+public MyClass(ILocalizedTextService textservice)
+{
+    var localizedLabel = textservice.Localize("dialog/mykey");
+}
+```
+
+### From Angular
+In the Umbraco backoffice UI, labels can be localized with the `localize` directive:
+
+```xml
+<button>
+    <localize key="dialog_myKey">Default value</localize>
+</button>
+```
+
+The localize directive can also be used as an attribute like below where the value of the title attribute is then populated with the dictionary key "title_name" from the language file using "@title_name".
+
+```xml
+<button localize="title" title="@title_name">
+    <localize key="dialog_myKey">Default value</localize>
+</button>
+```
+
+Or from a controller by using the `LocalizationService` which returns an async translation in a promise:
+
+```javascript
+localizationService.localize("dialog_myKey").then(function(value){
+                element.html(value);
+});
+```
+
+## Help keep the language files up to date
+
+As Umbraco is a continually evolving product it is inevitable that new text is added on a fairly regular basis to the English language version of these files. This may mean that some of the above languages are no longer up to date.
+
+If a translation is missing, the key "alias" used will be shown within the user interface, as an example:
+
+    [assignDomain]
+
+The language files are XML files with a straight-forward layout as seen below.
+
+```xml
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<language alias="en" intName="English (UK)" localName="English (UK)" lcid="" culture="en-GB">
+    <creator>
+        <name>The Umbraco community</name>
+        <link>https://our.umbraco.com</link>
+    </creator>
+    <area alias="actions">
+        <key alias="assignDomain">Culture and Hostnames</key>
+        <key alias="auditTrail">Audit Trail</key>
+        ...
+    </area>
+    ...
+</language>
+```
+
+In the above example of a missing translation for "assignDomain", locate this string in the en.xml file and then copy the whole "Key" element into the relevant language file. Then you can translate the text, as an example here is the Spanish version of the above snippet:
+
+```xml
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<language alias="es" intName="Spanish" localName="español" lcid="10" culture="es-ES">
+    <creator>
+        <name>The Umbraco community</name>
+        <link>https://our.umbraco.com</link>
+    </creator>
+    <area alias="actions">
+        <key alias="assignDomain">Administrar hostnames</key>
+        <key alias="auditTrail">Auditoría</key>
+        ...
+    </area>
+    ...
+</language>
+```
+
+If you do update any of the core language files or you add a new language, don't forget to help the rest of the community by [submitting a pull request](../../Contribute/index.md) so that your changes are merged into the core.


### PR DESCRIPTION
### Details
* I've updated the description and code in the "From .NET" section, to use dependency injection. 
* I also removed the initial "\~" in the Package language files and User language files section, since there now is a folder named "\~"  which might cause some confusion.
* I updated the folder path in "Core language files" to match the new folder names
* I haven't updated the links to other articles, since they haven't been migrated yet, and therefore doesn't exist. 

